### PR TITLE
removing copy directive for index.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,4 @@ RUN mkdir ./src \
 
 COPY webpack.config.js /docker
 
-COPY index.js /docker/src
-
 CMD ["bash"]


### PR DESCRIPTION
Allowing use to have their index.js file where they want.